### PR TITLE
Bind to slow the mouse down for building precision

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -27,6 +27,7 @@ MACRO_CONFIG_INT(ClAutoScreenshotMax, cl_auto_screenshot_max, 10, 0, 1000, CFGFL
 MACRO_CONFIG_INT(ClEventthread, cl_eventthread, 0, 0, 1, CFGFLAG_CLIENT, "Enables the usage of a thread to pump the events")
 
 MACRO_CONFIG_INT(InpGrab, inp_grab, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Use forceful input grabbing method")
+MACRO_CONFIG_INT(InpSlowMouseVal, inp_slow_mouse_val, 70, 10, 95, CFGFLAG_SAVE|CFGFLAG_CLIENT, "By how many percent the mouse movement will slow down when using +slow_mouse")
 
 MACRO_CONFIG_STR(BrFilterString, br_filter_string, 25, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Server browser filtering string")
 MACRO_CONFIG_INT(BrFilterFull, br_filter_full, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Filter out full server in browser")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -29,6 +29,7 @@ void CControls::OnReset()
 	m_LastData.m_Fire &= INPUT_STATE_MASK;
 	m_LastData.m_Jump = 0;
 	m_InputData = m_LastData;
+	m_SlowMouse = false;
 
 	m_InputDirectionLeft = 0;
 	m_InputDirectionRight = 0;
@@ -86,6 +87,7 @@ void CControls::OnConsoleInit()
 	Console()->Register("+jump", "", CFGFLAG_CLIENT, ConKeyInputState, &m_InputData.m_Jump, "Jump");
 	Console()->Register("+hook", "", CFGFLAG_CLIENT, ConKeyInputState, &m_InputData.m_Hook, "Hook");
 	Console()->Register("+fire", "", CFGFLAG_CLIENT, ConKeyInputCounter, &m_InputData.m_Fire, "Fire");
+	Console()->Register("+slow_mouse", "", CFGFLAG_CLIENT, ConKeyInputState, &m_SlowMouse, "Slow mouse for building precision");
 
 	{ static CInputSet s_Set = {this, &m_InputData.m_WantedWeapon, 1}; Console()->Register("+weapon1", "", CFGFLAG_CLIENT, ConKeyInputSet, (void *)&s_Set, "Switch to hammer"); }
 	{ static CInputSet s_Set = {this, &m_InputData.m_WantedWeapon, 2}; Console()->Register("+weapon2", "", CFGFLAG_CLIENT, ConKeyInputSet, (void *)&s_Set, "Switch to gun"); }
@@ -221,7 +223,8 @@ bool CControls::OnMouseMove(float x, float y)
 		(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_pChat->IsActive()))
 		return false;
 
-	m_MousePos += vec2(x, y); // TODO: ugly
+	float SlowMouseModifier = ((float)g_Config.m_InpSlowMouseVal/100.0f)*m_SlowMouse;
+	m_MousePos += vec2(x-x*SlowMouseModifier, y-y*SlowMouseModifier); // TODO: ugly
 	ClampMousePos();
 
 	return true;

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -10,6 +10,7 @@ class CControls : public CComponent
 public:
 	vec2 m_MousePos;
 	vec2 m_TargetPos;
+	int m_SlowMouse;
 
 	CNetObj_PlayerInput m_InputData;
 	CNetObj_PlayerInput m_LastData;


### PR DESCRIPTION
For high-sens players it might be extremely hard to build blocks exactly where they want.

This PR adds a key-command `+slow_mouse` and a config variable `inp_slow_mouse_val`. When holding down the key to which this command is bound, the mouse will move at a lower speed (configurable through the config variable) to gain more building precision.